### PR TITLE
Fix building inside Docker environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "tigerbeetle-unofficial"
-version = "0.4.0+0.15.3"
+version = "0.4.1+0.15.3"
 dependencies = [
  "bytemuck",
  "pollster",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "tigerbeetle-unofficial-core"
-version = "0.4.0+0.15.3"
+version = "0.4.1+0.15.3"
 dependencies = [
  "bytemuck",
  "sptr",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "tigerbeetle-unofficial-sys"
-version = "0.4.0+0.15.3"
+version = "0.4.1+0.15.3"
 dependencies = [
  "bindgen",
  "bitflags 2.6.0",

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -90,6 +90,8 @@ fn main() {
         .arg("c_client")
         .args((!debug).then_some("-Drelease"))
         .arg(format!("-Dtarget={target_lib_subdir}"))
+        // TODO: Remove once fixed in upstream.
+        .arg("-Dgit-commit=73bbc1a32ba2513e369764680350c099fe302285")
         .env("TIGERBEETLE_RELEASE", TIGERBEETLE_RELEASE)
         .current_dir(&tigerbeetle_root)
         .status()


### PR DESCRIPTION
Building crate inside Docker container fails with `fatal: not a git repository (or any of the parent directories): .git` error.